### PR TITLE
switching to new email address

### DIFF
--- a/abstracts.md
+++ b/abstracts.md
@@ -6,7 +6,7 @@ github: 'https://github.com/OSSFE/OSSFE_2026'
 
 
 # Submit your abstract
-To submit an abstract, please fill out the form below. If you have any questions regarding the submission process, feel free to reach out to us at ossfecontact@gmail.com.
+To submit an abstract, please fill out the form below. If you have any questions regarding the submission process, feel free to reach out to us at contact@ossfe.org
 
 {button}`Go to submission form <https://forms.gle/PE4Q2khDxQpKTxWu6>`
 

--- a/contact.md
+++ b/contact.md
@@ -9,7 +9,7 @@ github: 'https://github.com/OSSFE/OSSFE_2026'
 Have any questions or need further information about the Open Source Software for Fusion Energy (OSSFE) Conference? We’re here to help! Feel free to reach out to us for any inquiries regarding registration, the program, or technical support.
 
 For general questions about the conference, please contact us at:
-Email: ossfecontact@gmail.com
+Email: contact@ossfe.org
 
 We aim to respond to all inquiries promptly. We look forward to seeing you at OSSFE 2026!
 

--- a/registration.md
+++ b/registration.md
@@ -9,7 +9,7 @@ github: 'https://github.com/OSSFE/OSSFE_2026'
 
 
 # Register for OSSFE 2026
-We are excited to welcome you to the Open Source Software for Fusion Energy (OSSFE) Conference 2026! Registration is not yet open. If you have any questions regarding the registration process, feel free to reach out to us at ossfecontact@gmail.com.
+We are excited to welcome you to the Open Source Software for Fusion Energy (OSSFE) Conference 2026! Registration is not yet open. If you have any questions regarding the registration process, feel free to reach out to us at contact@ossfe.org
 
 Registration costs: TBD
 

--- a/sponsor.md
+++ b/sponsor.md
@@ -19,7 +19,7 @@ Last year, OSSFE attracted 240+ people from more than 100 different institutions
 ```
 {button}`Full-screen <https://remdelaportemathurin.github.io/interactive-plots/ossfe_2025_stats/>`
 
-If you're interested in sponsoring OSSFE 2026, get in touch with us at ossfecontact@gmail.com !
+If you're interested in sponsoring OSSFE 2026, get in touch with us at contact@ossfe.org !
 
 ## Previous sponsors
 ```{image} assets/sponsor_logos.png


### PR DESCRIPTION
We might not want to merge this yet but if we do switch to the new email address then this PR updates the website to contact@ossfe.org